### PR TITLE
.travis.yml comment about branches & badges not quite right

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,14 +59,17 @@ matrix:
 ###
 ### limit build attempts to defined branches
 ###
-### - Seems to be the only way to keep feature branches from
-###   breaking web badges.  Wouldn't this functionality make
-###   more sense in allow_failures, above?
+###     branches:
+###       only:
+###         - master
 ###
-
-branches:
-  only:
-    - master
+### - If you do not wish all branches to affect the web badge, but
+###   still wish all branches to build, you can limit the branches
+###   that affect the web badge by appending
+###   "?branch=master,staging,production" to the end of the image URL
+###   (replacing "master,staging,production" with a comma separated
+###   list of branches).
+###
 
 ###
 ### runtime initialization


### PR DESCRIPTION
The .travis.yml [mentions](https://github.com/rolandwalker/emacs-travis/blob/master/.travis.yml#L62) that limiting builds to the master branch is the only way to keep feature branches from breaking badges.  This isn't quite true.  You can limit which branch a badge represents (as [explained in their docs](http://about.travis-ci.org/docs/user/status-images/)).  I'll happily provide a patch, but I wanted to see whether the limit of only building the master branch should stay, or become a comment.  Either way, I figure that the ability to limit which branch the badge represents should be added to the comment.
